### PR TITLE
Add rules to ignore build outputs in subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+# Ignore all build outputs in all subdirectories
 target/
+**/target/


### PR DESCRIPTION
As requested I've improved it so it now also ignores subdirectories' build outputs